### PR TITLE
Fix error in host monitoring when current_stage is not set

### DIFF
--- a/monitor_host/tasks/hosts_monitoring.yml
+++ b/monitor_host/tasks/hosts_monitoring.yml
@@ -8,9 +8,9 @@
     status_code: [200, 201]
     return_content: True
   register: host
-  until: (host.json.progress.current_stage == 'Rebooting' and host.json.status == 'installing-pending-user-action')
+  until: (host.json.progress.current_stage|default('') == 'Rebooting' and host.json.status == 'installing-pending-user-action')
          or
-         host.json.progress.current_stage in ['Configuring', 'Done']
+         host.json.progress.current_stage|default('') in ['Configuring', 'Done']
   retries: 60
   delay: 60
 
@@ -19,4 +19,4 @@
     name: boot_disk
   vars:
     hosts: "{{ host.json.requested_hostname }}"
-  when: host.json.progress.current_stage == 'Rebooting' and host.json.status == 'installing-pending-user-action'
+  when: host.json.progress.current_stage|default('') == 'Rebooting' and host.json.status == 'installing-pending-user-action'


### PR DESCRIPTION
Host monitor task is failing with:
'dict object' has no attribute 'current_stage'

Seems to be a race with the API status. Default the current_stage to ''
in the condition should avoid it.